### PR TITLE
Release 2.0.0-beta.3

### DIFF
--- a/LASDKiOS/2.0.0-beta.3/LASDKiOS.podspec
+++ b/LASDKiOS/2.0.0-beta.3/LASDKiOS.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+s.name              = 'LASDKiOS'
+s.version           = '2.0.0-beta3'
+s.summary           = 'LASDKiOS XCFramework'
+s.homepage          = 'https://github.com/cbajapan/swift-lasdk-ios'
+
+s.author            = { 'Name' => 'Communication Business Avenue, Inc.' }
+s.license           = { :type => 'Commercial', :text => 'Copyright Communication Business Avenue, Inc. Use of this software is subject to the terms and conditions located at https://github.com/cbajapan/swift-lasdk-ios/blob/main/License.txt'}
+
+s.source            = { :http => 'https://swift-sdk.s3.us-east-2.amazonaws.com/lasdk/LASDKiOS-2.0.0-beta.3.xcframework.zip' }
+
+s.platforms = { :ios => "11.0" }
+
+s.vendored_frameworks = 'LASDKiOS.xcframework'
+end

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
                 "WebRTC"
             ]
         ),
-        .binaryTarget(name: "LASDKiOS", url: "https://swift-sdk.s3.us-east-2.amazonaws.com/lasdk/LASDKiOS-2.0.0-beta.2.xcframework.zip", checksum: "e6764fab1c661c824d6f3b7b9809995294f4b20401f85f15d51062ec97699ace"),
+        .binaryTarget(name: "LASDKiOS", url: "https://swift-sdk.s3.us-east-2.amazonaws.com/lasdk/LASDKiOS-2.0.0-beta.3.xcframework.zip", checksum: "f053d9140a78817ac6aaf7df61dae5279d0a6848e445316d2632fc11b43bd4bd"),
         .binaryTarget(name: "WebRTC", url: "https://swift-sdk.s3.us-east-2.amazonaws.com/real_time/WebRTC-m110.xcframework.zip", checksum: "2750cf1087b2441d67208ca2b0905578b4ad1797a68d2d2758d0f075500f0011")
     ]
 )


### PR DESCRIPTION
Updates to the new Release 2.0.0-beta.3 binary

In this release, note that there's a slight API change since 2.0.0-beta.2

In `AssistSDK`:
```
    @objc public class func parseURL(_ config: Configuration?, serverURL: String? = nil) throws -> ServerObject
```
has changed to:
```
    @objc public class func parseServerURL(_ serverURL: String) throws -> ServerObject
```

In addition to this, the default behaviour for the `server` value of the `Configuration` object has changed to be more in line with the ObjectiveC version of the SDK.

- When specifying _just_ a host (e.g. `liveassisttest.usaa.com`) the SDK will default to `http` over port `8080`
- When specifying _just_ a scheme and host (e.g. `http://liveassisttest.usaa.com`) the SDK will default to the default port for that scheme (`8080` for `http` and `8443` for `https`)
- When specifying _just_ a host and port (e.g. `liveassisttest.usaa.com:80`) the SDK will default to `http`
- In most cases, we recommend that you provide the scheme, host and port, e.g. `https://liveassisttest.usaa.com:443`
